### PR TITLE
feat: LinkedIn-branded fallback banner for non-embeddable posts

### DIFF
--- a/src/pages/linkedin/index.astro
+++ b/src/pages/linkedin/index.astro
@@ -51,7 +51,7 @@ function extractLinkedInActivityId(url: string): string | null {
               data-tags={post.data.tags.join(',')}
             >
               {/* LinkedIn Embed */}
-              {activityId && (
+              {activityId ? (
                 <div class="w-full bg-gray-100 dark:bg-dark/30">
                   <iframe
                     src={`https://www.linkedin.com/embed/feed/update/urn:li:activity:${activityId}`}
@@ -64,6 +64,24 @@ function extractLinkedInActivityId(url: string): string | null {
                     class="border-0"
                   />
                 </div>
+              ) : (
+                <a
+                  href={post.data.linkedinUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="block w-full bg-gradient-to-br from-[#0077B5] to-[#005582] p-6 text-white no-underline hover:from-[#0088cc] hover:to-[#006699] transition-all"
+                >
+                  <div class="flex items-center gap-3 mb-3">
+                    <svg class="h-8 w-8 flex-shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+                    </svg>
+                    <span class="text-sm font-medium opacity-90">LinkedIn Article</span>
+                  </div>
+                  <p class="text-lg font-semibold leading-snug line-clamp-2">{post.data.title}</p>
+                  <span class="inline-flex items-center gap-1 mt-3 text-sm font-medium opacity-90 hover:opacity-100">
+                    View on LinkedIn →
+                  </span>
+                </a>
               )}
 
               {/* Post Details */}


### PR DESCRIPTION
Pulse articles and other LinkedIn URLs without an activity ID now show a styled gradient banner with LinkedIn logo and 'View on LinkedIn →' link, instead of just text.