### PR TITLE
Remove duplicate title field from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/article.yml
+++ b/.github/ISSUE_TEMPLATE/article.yml
@@ -1,21 +1,11 @@
 name: Submit an Article
 description: Share a blog post or article about Microsoft Fabric Data Agents.
-title: "[Article] "
 labels: ["content-submission", "article"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for sharing an article with the community. Please fill out the fields below. All fields marked with an asterisk (*) are required.
-
-  - type: input
-    id: title
-    attributes:
-      label: Article Title
-      description: The title of the article as it appears on the source.
-      placeholder: "e.g. Getting Started with Microsoft Fabric Data Agents"
-    validations:
-      required: true
 
   - type: input
     id: url

--- a/.github/ISSUE_TEMPLATE/event.yml
+++ b/.github/ISSUE_TEMPLATE/event.yml
@@ -1,21 +1,11 @@
 name: Submit an Event
 description: Share an upcoming conference, webinar, meetup, or session about Fabric Data Agents.
-title: "[Event] "
 labels: ["content-submission", "event"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for sharing an event with the community. Please fill out the fields below.
-
-  - type: input
-    id: title
-    attributes:
-      label: Event Title
-      description: The name of the event.
-      placeholder: "e.g. Microsoft Fabric Community Conference 2026"
-    validations:
-      required: true
 
   - type: input
     id: url

--- a/.github/ISSUE_TEMPLATE/linkedin.yml
+++ b/.github/ISSUE_TEMPLATE/linkedin.yml
@@ -1,21 +1,11 @@
 name: Submit a LinkedIn Post
 description: Share a LinkedIn post about Microsoft Fabric Data Agents.
-title: "[LinkedIn] "
 labels: ["content-submission", "linkedin"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for sharing a LinkedIn post with the community. Please fill out the fields below.
-
-  - type: input
-    id: title
-    attributes:
-      label: Post Title
-      description: A short descriptive title for the post.
-      placeholder: "e.g. My Experience Building Data Agents"
-    validations:
-      required: true
 
   - type: input
     id: linkedin_url

--- a/.github/ISSUE_TEMPLATE/resource.yml
+++ b/.github/ISSUE_TEMPLATE/resource.yml
@@ -1,21 +1,11 @@
 name: Submit a Resource
 description: Share a documentation page, repository, tutorial, or other resource.
-title: "[Resource] "
 labels: ["content-submission", "resource"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for sharing a resource with the community. Please fill out the fields below.
-
-  - type: input
-    id: title
-    attributes:
-      label: Resource Title
-      description: A descriptive title for the resource.
-      placeholder: "e.g. Official Fabric Data Agent Documentation"
-    validations:
-      required: true
 
   - type: input
     id: url

--- a/.github/ISSUE_TEMPLATE/tool.yml
+++ b/.github/ISSUE_TEMPLATE/tool.yml
@@ -1,21 +1,11 @@
 name: Submit a Tool
 description: Share a tool, library, or utility related to Fabric Data Agents.
-title: "[Tool] "
 labels: ["content-submission", "tool"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for sharing a tool with the community. Please fill out the fields below.
-
-  - type: input
-    id: title
-    attributes:
-      label: Tool Name
-      description: The name of the tool or library.
-      placeholder: "e.g. Semantic Link Labs"
-    validations:
-      required: true
 
   - type: input
     id: url

--- a/.github/ISSUE_TEMPLATE/video.yml
+++ b/.github/ISSUE_TEMPLATE/video.yml
@@ -1,21 +1,11 @@
 name: Submit a Video
 description: Share a YouTube video about Microsoft Fabric Data Agents.
-title: "[Video] "
 labels: ["content-submission", "video"]
 body:
   - type: markdown
     attributes:
       value: |
         Thanks for sharing a video with the community. Please fill out the fields below.
-
-  - type: input
-    id: title
-    attributes:
-      label: Video Title
-      description: The title of the video.
-      placeholder: "e.g. Building Your First Data Agent"
-    validations:
-      required: true
 
   - type: input
     id: youtube_id

--- a/.github/workflows/add-content.yml
+++ b/.github/workflows/add-content.yml
@@ -191,10 +191,10 @@ jobs:
             const errors = [];
 
             let frontmatter = '';
-            let title = '';
+            // Extract title from issue title (strips [Type] prefix for backward compatibility)
+            let title = issue.title.replace(/^\[.*?\]\s*/, '').trim();
 
             if (contentType === 'article') {
-              title = parseField(body, 'Article Title');
               const url = validateUrl(parseField(body, 'Article URL'));
               const author = parseField(body, 'Author');
               const publishDate = validateDate(parseField(body, 'Publish Date'));
@@ -203,7 +203,6 @@ jobs:
               const contributor = parseField(body, 'Your Name');
               const notes = parseField(body, 'Additional Notes');
 
-              if (!title) errors.push('Article Title is required');
               if (!url) errors.push('Article URL is missing or invalid (must be a full URL starting with http)');
               if (!summary) errors.push('Summary is required');
 
@@ -227,7 +226,6 @@ jobs:
               }
 
             } else if (contentType === 'video') {
-              title = parseField(body, 'Video Title');
               const youtubeId = extractYouTubeId(parseField(body, 'YouTube Video ID'));
               const speaker = parseField(body, 'Speaker / Presenter');
               const publishDate = validateDate(parseField(body, 'Publish Date'));
@@ -235,7 +233,6 @@ jobs:
               const tags = parseField(body, 'Tags');
               const contributor = parseField(body, 'Your Name');
 
-              if (!title) errors.push('Video Title is required');
               if (!youtubeId) errors.push('YouTube Video ID is required');
               if (!description) errors.push('Description is required');
 
@@ -254,14 +251,12 @@ jobs:
               }
 
             } else if (contentType === 'resource') {
-              title = parseField(body, 'Resource Title');
               const url = validateUrl(parseField(body, 'Resource URL'));
               const description = parseField(body, 'Description');
               const category = parseField(body, 'Category');
               const tags = parseField(body, 'Tags');
               const contributor = parseField(body, 'Your Name');
 
-              if (!title) errors.push('Resource Title is required');
               if (!url) errors.push('Resource URL is missing or invalid');
               if (!description) errors.push('Description is required');
 
@@ -282,7 +277,6 @@ jobs:
               }
 
             } else if (contentType === 'event') {
-              title = parseField(body, 'Event Title');
               const url = validateUrl(parseField(body, 'Event URL'));
               const date = validateDate(parseField(body, 'Event Date'));
               const endDate = validateDate(parseField(body, 'End Date (optional)'));
@@ -292,7 +286,6 @@ jobs:
               const tags = parseField(body, 'Tags');
               const contributor = parseField(body, 'Your Name');
 
-              if (!title) errors.push('Event Title is required');
               if (!url) errors.push('Event URL is missing or invalid');
               if (!date) errors.push('Event Date is missing or invalid (use YYYY-MM-DD format)');
               if (!description) errors.push('Description is required');
@@ -326,14 +319,12 @@ jobs:
               }
 
             } else if (contentType === 'tool') {
-              title = parseField(body, 'Tool Name');
               const url = validateUrl(parseField(body, 'Tool URL'));
               const description = parseField(body, 'Description');
               const category = parseField(body, 'Category');
               const tags = parseField(body, 'Tags');
               const contributor = parseField(body, 'Your Name');
 
-              if (!title) errors.push('Tool Name is required');
               if (!url) errors.push('Tool URL is missing or invalid');
               if (!description) errors.push('Description is required');
 
@@ -354,14 +345,12 @@ jobs:
               }
 
             } else if (contentType === 'linkedin') {
-              title = parseField(body, 'Post Title');
               const linkedinUrl = validateUrl(parseField(body, 'LinkedIn Post URL'));
               const author = parseField(body, 'Post Author');
               const description = parseField(body, 'Description');
               const tags = parseField(body, 'Tags');
               const contributor = parseField(body, 'Your Name');
 
-              if (!title) errors.push('Post Title is required');
               if (!linkedinUrl) errors.push('LinkedIn Post URL is missing or invalid');
               if (!description) errors.push('Description is required');
 


### PR DESCRIPTION
## Summary
Users previously had to type their content title **twice**: once in the issue title bar (with a confusing \[Article]\ prefix) and again in a form field. This PR eliminates the redundancy.

### Changes
- **Removed \[Type]\ prefix** from all 6 issue template titles — no more confusing brackets for users
- **Removed redundant title form input** from article, video, resource, tool, event, and linkedin templates
- **Updated workflow** to read title directly from \issue.title\ (with backward-compatible prefix stripping for existing issues)

### Before → After
| Before | After |
|--------|-------|
| Issue title: \[Article] \ + form field: \Article Title\ | Just the issue title field |
| User types title twice | User types title once |
| Confusing \[]\ brackets | Clean title field |

### Backward Compatibility
- Old issues with \[Type]\ prefix in the title still work — prefix is stripped automatically
- Content type detection unchanged (uses labels, not title prefix)
