### PR TITLE
feat: Show author/speaker/creator on content cards (closes #43, #44)

### DIFF
--- a/.github/ISSUE_TEMPLATE/resource.yml
+++ b/.github/ISSUE_TEMPLATE/resource.yml
@@ -16,6 +16,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: author
+    attributes:
+      label: Creator / Author
+      description: The original creator or author of this resource.
+      placeholder: "e.g. Microsoft Learn, Jane Smith"
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/tool.yml
+++ b/.github/ISSUE_TEMPLATE/tool.yml
@@ -16,6 +16,15 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: author
+    attributes:
+      label: Creator / Author
+      description: The original creator or author of this tool.
+      placeholder: "e.g. Jane Smith, Contoso Labs"
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:

--- a/.github/workflows/add-content.yml
+++ b/.github/workflows/add-content.yml
@@ -252,6 +252,7 @@ jobs:
 
             } else if (contentType === 'resource') {
               const url = validateUrl(parseField(body, 'Resource URL'));
+              const author = parseField(body, 'Creator / Author');
               const description = parseField(body, 'Description');
               const category = parseField(body, 'Category');
               const tags = parseField(body, 'Tags');
@@ -268,12 +269,13 @@ jobs:
                   '---',
                   `title: "${yamlSafe(title)}"`,
                   `url: "${url}"`,
+                  author ? `author: "${yamlSafe(author)}"` : null,
                   `description: "${yamlSafe(description)}"`,
                   `category: "${yamlSafe(category)}"`,
                   `tags: ${formatTags(tags)}`,
                   `contributor: "${yamlSafe(contributor)}"`,
                   '---'
-                ].join('\n');
+                ].filter(Boolean).join('\n');
               }
 
             } else if (contentType === 'event') {
@@ -320,6 +322,7 @@ jobs:
 
             } else if (contentType === 'tool') {
               const url = validateUrl(parseField(body, 'Tool URL'));
+              const author = parseField(body, 'Creator / Author');
               const description = parseField(body, 'Description');
               const category = parseField(body, 'Category');
               const tags = parseField(body, 'Tags');
@@ -336,12 +339,13 @@ jobs:
                   '---',
                   `title: "${yamlSafe(title)}"`,
                   `url: "${url}"`,
+                  author ? `author: "${yamlSafe(author)}"` : null,
                   `description: "${yamlSafe(description)}"`,
                   `category: "${yamlSafe(category)}"`,
                   `tags: ${formatTags(tags)}`,
                   `contributor: "${yamlSafe(contributor)}"`,
                   '---'
-                ].join('\n');
+                ].filter(Boolean).join('\n');
               }
 
             } else if (contentType === 'linkedin') {

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -14,6 +14,8 @@ Every change, no matter how small, follows this process:
 6. **Review** - CI must pass. Maintainer reviews before merge.
 7. **Deploy** - Merging to `main` triggers automatic deployment to GitHub Pages.
 
+**Important:** Never merge or close PRs automatically. Only the maintainer merges or closes PRs unless explicitly asked to do so.
+
 ## Pre-Change Checklist
 
 Before starting any change, verify:

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -4,12 +4,20 @@ interface Props {
   description?: string;
   url?: string;
   tags?: string[];
-  contributor?: string;
+  author?: string;
   type?: 'article' | 'resource' | 'video' | 'event' | 'tool';
   date?: string;
 }
 
-const { title, description, url, tags = [], contributor, type = 'article', date } = Astro.props;
+const { title, description, url, tags = [], author, type = 'article', date } = Astro.props;
+
+const authorLabels: Record<string, string> = {
+  article: 'Author',
+  video: 'Speaker',
+  resource: 'Creator',
+  tool: 'Creator',
+};
+const authorLabel = authorLabels[type];
 const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 
 const typeIcons: Record<string, string> = {
@@ -47,7 +55,7 @@ const domain = url ? (() => {
   data-flyout-url={url || ''}
   data-flyout-type={type}
   data-flyout-date={formattedDate || ''}
-  data-flyout-contributor={contributor || ''}
+  data-flyout-author={author || ''}
 >
   <!-- Type badge -->
   <div class="mb-3 flex items-center justify-between">
@@ -117,15 +125,13 @@ const domain = url ? (() => {
   <!-- Extra content slot -->
   <slot />
 
-  <!-- Contributor -->
-  {contributor && (
-    <a href={`${base}contributors/${contributor.toLowerCase().replace(/[^a-z0-9]+/g, '-')}/`}
-       class="flex items-center gap-1.5 text-xs text-gray-400 dark:text-muted/60 hover:text-teal transition-colors relative z-10"
-       onclick="event.stopPropagation()">
+  <!-- Author / Speaker / Creator -->
+  {author && authorLabel && (
+    <div class="flex items-center gap-1.5 text-xs text-gray-400 dark:text-muted/60">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
       </svg>
-      <span>{contributor}</span>
-    </a>
+      <span>{authorLabel}: {author}</span>
+    </div>
   )}
 </div>

--- a/src/components/FlyoutPanel.astro
+++ b/src/components/FlyoutPanel.astro
@@ -59,13 +59,13 @@
       <div id="flyout-tags" class="flex flex-wrap gap-2"></div>
     </div>
 
-    <!-- Contributor & submission info -->
+    <!-- Author info -->
     <div class="flex items-center gap-4 text-sm text-gray-400 dark:text-muted/60 border-t border-gray-200 dark:border-indigo/10 pt-4">
-      <div id="flyout-contributor" class="flex items-center gap-1.5">
+      <div id="flyout-author" class="flex items-center gap-1.5">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
         </svg>
-        <span id="flyout-contributor-name"></span>
+        <span id="flyout-author-name"></span>
       </div>
     </div>
 
@@ -145,9 +145,12 @@ function initFlyout() {
       tagsContainer.classList.add('hidden');
     }
 
-    // Contributor
-    document.getElementById('flyout-contributor-name')!.textContent = data.contributor || '';
-    document.getElementById('flyout-contributor')!.classList.toggle('hidden', !data.contributor);
+    // Author
+    const authorLabels: Record<string, string> = { article: 'Author', video: 'Speaker', resource: 'Creator', tool: 'Creator', linkedin: 'Author' };
+    const authorLabel = authorLabels[data.type] || '';
+    const authorName = data.author || '';
+    document.getElementById('flyout-author-name')!.textContent = authorName ? `${authorLabel}: ${authorName}` : '';
+    document.getElementById('flyout-author')!.classList.toggle('hidden', !authorName);
 
     // CTA
     const cta = document.getElementById('flyout-cta') as HTMLAnchorElement;
@@ -205,7 +208,7 @@ function initFlyout() {
       type: detail.type || 'article',
       date: detail.date || '',
       tags: detail.tags || '',
-      contributor: detail.contributor || '',
+      author: detail.author || '',
       youtubeId: detail.youtubeId || '',
       linkedinActivityId: detail.linkedinActivityId || '',
     });
@@ -225,7 +228,7 @@ function initFlyout() {
         type: el.dataset.flyoutType || 'article',
         date: el.dataset.flyoutDate || '',
         tags: el.dataset.tags || '',
-        contributor: el.dataset.flyoutContributor || '',
+        author: el.dataset.flyoutAuthor || '',
         youtubeId: el.dataset.flyoutYoutubeid || '',
         linkedinActivityId: el.dataset.flyoutLinkedinactivityid || '',
       });

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -20,6 +20,7 @@ const resources = defineCollection({
   schema: z.object({
     title: z.string(),
     url: z.string().url(),
+    author: z.string().optional(),
     description: z.string(),
     category: z.string(),
     tags: z.array(z.string()).default([]),
@@ -73,6 +74,7 @@ const tools = defineCollection({
   schema: z.object({
     title: z.string(),
     url: z.string().url(),
+    author: z.string().optional(),
     description: z.string(),
     category: z.string(),
     tags: z.array(z.string()).default([]),

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -38,17 +38,10 @@ const allTags = [...new Set(articles.flatMap((a) => a.data.tags))].sort();
             description={article.data.summary}
             url={article.data.url}
             tags={article.data.tags}
-            contributor={article.data.contributor}
+            author={article.data.author}
             type="article"
             date={new Date(article.data.publishDate).toLocaleDateString()}
-          >
-            {(article.data.submittedDate || article.data.publishDate) && (
-              <div class="mt-2 space-y-0.5 text-xs text-gray-400 dark:text-muted/60">
-                <p>Published: {new Date(article.data.publishDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</p>
-                <p>Submitted: {new Date(article.data.submittedDate ?? article.data.publishDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}</p>
-              </div>
-            )}
-          </ContentCard>
+          />
         ))}
       </div>
     ) : (

--- a/src/pages/contributors/[name].astro
+++ b/src/pages/contributors/[name].astro
@@ -47,12 +47,12 @@ const contribLinkedin = byContributor(linkedin);
 const totalCount = contribArticles.length + contribResources.length + contribVideos.length + contribEvents.length + contribTools.length + contribLinkedin.length;
 
 const sections = [
-  { title: '📄 Articles', items: contribArticles, type: 'article' as const, getDesc: (i: any) => i.data.summary, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.publishDate },
-  { title: '📚 Resources', items: contribResources, type: 'resource' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined },
-  { title: '🎬 Videos', items: contribVideos, type: 'video' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => `https://www.youtube.com/watch?v=${i.data.youtubeId}`, getDate: (i: any) => i.data.publishDate },
-  { title: '📅 Events', items: contribEvents, type: 'event' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.date },
-  { title: '🔧 Tools', items: contribTools, type: 'tool' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined },
-  { title: '💼 LinkedIn Posts', items: contribLinkedin, type: 'article' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.linkedinUrl, getDate: (i: any) => i.data.submittedDate },
+  { title: '📄 Articles', items: contribArticles, type: 'article' as const, getDesc: (i: any) => i.data.summary, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.publishDate, getAuthor: (i: any) => i.data.author },
+  { title: '📚 Resources', items: contribResources, type: 'resource' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined, getAuthor: (i: any) => i.data.author },
+  { title: '🎬 Videos', items: contribVideos, type: 'video' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => `https://www.youtube.com/watch?v=${i.data.youtubeId}`, getDate: (i: any) => i.data.publishDate, getAuthor: (i: any) => i.data.speaker },
+  { title: '📅 Events', items: contribEvents, type: 'event' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.date, getAuthor: () => undefined },
+  { title: '🔧 Tools', items: contribTools, type: 'tool' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined, getAuthor: (i: any) => i.data.author },
+  { title: '💼 LinkedIn Posts', items: contribLinkedin, type: 'article' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.linkedinUrl, getDate: (i: any) => i.data.submittedDate, getAuthor: (i: any) => i.data.author },
 ];
 ---
 
@@ -70,7 +70,7 @@ const sections = [
       </a>
     </div>
 
-    {sections.map(({ title, items, type, getDesc, getUrl, getDate }) =>
+    {sections.map(({ title, items, type, getDesc, getUrl, getDate, getAuthor }) =>
       items.length > 0 && (
         <div class="mb-12">
           <h2 class="mb-6 text-xl font-bold text-gray-900 dark:text-light">{title}</h2>
@@ -81,7 +81,7 @@ const sections = [
                 description={getDesc(item)}
                 url={getUrl(item)}
                 tags={item.data.tags}
-                contributor={item.data.contributor}
+                author={getAuthor(item)}
                 type={type}
                 date={getDate(item) ? new Date(getDate(item)).toLocaleDateString() : undefined}
               />

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -65,7 +65,6 @@ function formatEventDate(date: Date, endDate?: Date): string {
               description={event.data.description}
               url={event.data.url}
               tags={event.data.tags}
-              contributor={event.data.contributor}
               type="event"
               date={event.data.date.toISOString()}
             />
@@ -105,7 +104,6 @@ function formatEventDate(date: Date, endDate?: Date): string {
               description={event.data.description}
               url={event.data.url}
               tags={event.data.tags}
-              contributor={event.data.contributor}
               type="event"
               date={event.data.date.toISOString()}
             />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ interface SectionItem {
   description: string;
   url: string;
   tags: string[];
-  contributor: string;
+  author?: string;
   date?: string;
 }
 
@@ -52,13 +52,14 @@ function toSectionItems(
   getDescription: (d: any) => string,
   getUrl: (d: any) => string,
   dateField?: string,
+  authorField?: string,
 ): SectionItem[] {
   return items.map(item => ({
     title: item.data.title,
     description: getDescription(item.data),
     url: getUrl(item.data),
     tags: item.data.tags,
-    contributor: item.data.contributor,
+    author: authorField ? item.data[authorField] : undefined,
     date: dateField && item.data[dateField] ? new Date(item.data[dateField]).toISOString() : undefined,
   }));
 }
@@ -72,11 +73,11 @@ const difficultyColors: Record<string, { bg: string; text: string }> = {
 const siteUrl = Astro.site?.toString() || 'https://fabricdataagent.com';
 
 const sections = [
-  { key: 'articles', label: 'Articles', href: `${base}articles/`, items: toSectionItems(latestArticles, d => d.summary, d => d.url, 'publishDate'), type: 'article' as const },
-  { key: 'videos', label: 'Videos', href: `${base}videos/`, items: toSectionItems(latestVideos, d => d.description, d => `https://www.youtube.com/watch?v=${d.youtubeId}`, 'publishDate'), type: 'video' as const },
+  { key: 'articles', label: 'Articles', href: `${base}articles/`, items: toSectionItems(latestArticles, d => d.summary, d => d.url, 'publishDate', 'author'), type: 'article' as const },
+  { key: 'videos', label: 'Videos', href: `${base}videos/`, items: toSectionItems(latestVideos, d => d.description, d => `https://www.youtube.com/watch?v=${d.youtubeId}`, 'publishDate', 'speaker'), type: 'video' as const },
   { key: 'events', label: 'Events', href: `${base}events/`, items: toSectionItems(latestEvents, d => d.description, d => d.url, 'date'), type: 'event' as const },
-  { key: 'resources', label: 'Resources', href: `${base}resources/`, items: toSectionItems(latestResources, d => d.description, d => d.url), type: 'resource' as const },
-  { key: 'tools', label: 'Tools', href: `${base}tools/`, items: toSectionItems(latestTools, d => d.description, d => d.url), type: 'tool' as const },
+  { key: 'resources', label: 'Resources', href: `${base}resources/`, items: toSectionItems(latestResources, d => d.description, d => d.url, undefined, 'author'), type: 'resource' as const },
+  { key: 'tools', label: 'Tools', href: `${base}tools/`, items: toSectionItems(latestTools, d => d.description, d => d.url, undefined, 'author'), type: 'tool' as const },
 ];
 ---
 
@@ -518,7 +519,7 @@ const sections = [
               description={item.description}
               url={item.url}
               tags={item.tags}
-              contributor={item.contributor}
+              author={item.author}
               type={type}
               date={item.date}
             />
@@ -554,7 +555,7 @@ const sections = [
             data-flyout-url={post.data.linkedinUrl}
             data-flyout-type="linkedin"
             data-flyout-date={new Date(post.data.submittedDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-            data-flyout-contributor={post.data.contributor}
+            data-flyout-author={post.data.author}
           >
             <div class="mb-3 flex items-center justify-between">
               <span class="inline-flex items-center gap-1 rounded-md bg-gray-100 dark:bg-indigo/20 px-2 py-1 text-xs font-medium text-gray-500 dark:text-muted">
@@ -579,12 +580,12 @@ const sections = [
                 ))}
               </div>
             )}
-            {post.data.contributor && (
+            {post.data.author && (
               <div class="flex items-center gap-1.5 text-xs text-gray-400 dark:text-muted/60">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                 </svg>
-                <span>{post.data.contributor}</span>
+                <span>Author: {post.data.author}</span>
               </div>
             )}
           </div>

--- a/src/pages/resources/index.astro
+++ b/src/pages/resources/index.astro
@@ -35,7 +35,7 @@ const allTags = [...new Set(allResources.flatMap((r) => r.data.tags))];
               description={resource.data.description}
               url={resource.data.url}
               tags={resource.data.tags}
-              contributor={resource.data.contributor}
+              author={resource.data.author}
               type="resource"
             />
           ))}

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -45,12 +45,12 @@ const taggedLinkedin = linkedin.filter(l => l.data.tags.includes(tag));
 const totalCount = taggedArticles.length + taggedResources.length + taggedVideos.length + taggedEvents.length + taggedTools.length + taggedLinkedin.length;
 
 const sections = [
-  { title: '📄 Articles', items: taggedArticles, type: 'article' as const, getDesc: (i: any) => i.data.summary, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.publishDate },
-  { title: '📚 Resources', items: taggedResources, type: 'resource' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined },
-  { title: '🎬 Videos', items: taggedVideos, type: 'video' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => `https://www.youtube.com/watch?v=${i.data.youtubeId}`, getDate: (i: any) => i.data.publishDate },
-  { title: '📅 Events', items: taggedEvents, type: 'event' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.date },
-  { title: '🔧 Tools', items: taggedTools, type: 'tool' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined },
-  { title: '💼 LinkedIn Posts', items: taggedLinkedin, type: 'article' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.linkedinUrl, getDate: (i: any) => i.data.submittedDate },
+  { title: '📄 Articles', items: taggedArticles, type: 'article' as const, getDesc: (i: any) => i.data.summary, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.publishDate, getAuthor: (i: any) => i.data.author },
+  { title: '📚 Resources', items: taggedResources, type: 'resource' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined, getAuthor: (i: any) => i.data.author },
+  { title: '🎬 Videos', items: taggedVideos, type: 'video' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => `https://www.youtube.com/watch?v=${i.data.youtubeId}`, getDate: (i: any) => i.data.publishDate, getAuthor: (i: any) => i.data.speaker },
+  { title: '📅 Events', items: taggedEvents, type: 'event' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: (i: any) => i.data.date, getAuthor: () => undefined },
+  { title: '🔧 Tools', items: taggedTools, type: 'tool' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.url, getDate: () => undefined, getAuthor: (i: any) => i.data.author },
+  { title: '💼 LinkedIn Posts', items: taggedLinkedin, type: 'article' as const, getDesc: (i: any) => i.data.description, getUrl: (i: any) => i.data.linkedinUrl, getDate: (i: any) => i.data.submittedDate, getAuthor: (i: any) => i.data.author },
 ];
 ---
 
@@ -68,7 +68,7 @@ const sections = [
       </a>
     </div>
 
-    {sections.map(({ title, items, type, getDesc, getUrl, getDate }) =>
+    {sections.map(({ title, items, type, getDesc, getUrl, getDate, getAuthor }) =>
       items.length > 0 && (
         <div class="mb-12">
           <h2 class="mb-6 text-xl font-bold text-gray-900 dark:text-light">{title}</h2>
@@ -79,7 +79,7 @@ const sections = [
                 description={getDesc(item)}
                 url={getUrl(item)}
                 tags={item.data.tags}
-                contributor={item.data.contributor}
+                author={getAuthor(item)}
                 type={type}
                 date={getDate(item) ? new Date(getDate(item)).toLocaleDateString() : undefined}
               />

--- a/src/pages/tools/index.astro
+++ b/src/pages/tools/index.astro
@@ -36,7 +36,7 @@ const allTags = [...new Set(tools.flatMap((t) => t.data.tags))].sort();
 							description={tool.data.description}
 							url={tool.data.url}
 							tags={tool.data.tags}
-							contributor={tool.data.contributor}
+							author={tool.data.author}
 							type="tool"
 						/>
 					</div>

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -61,7 +61,7 @@ const allTags = [...new Set(videos.flatMap((v) => v.data.tags))].sort();
               data-flyout-url={`https://www.youtube.com/watch?v=${video.data.youtubeId}`}
               data-flyout-type="video"
               data-flyout-date={new Date(video.data.publishDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })}
-              data-flyout-contributor={video.data.contributor}
+              data-flyout-author={video.data.speaker}
               data-flyout-youtubeid={video.data.youtubeId}
               data-tags={video.data.tags.join(',')}
             >
@@ -84,7 +84,7 @@ const allTags = [...new Set(videos.flatMap((v) => v.data.tags))].sort();
               )}
 
               <p class="text-xs text-gray-400 dark:text-muted/60 pt-2">
-                Contributed by {video.data.contributor}
+                Speaker: {video.data.speaker}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Changes

Replaces **Created By** (contributor) display on content cards with the actual content author, using type-appropriate labels:

| Content Type | Field | Card Label |
|---|---|---|
| Article | author | Author |
| LinkedIn | author | Author |
| Video | speaker | Speaker |
| Resource | author (new) | Creator |
| Tool | author (new) | Creator |
| Event | — | (not shown) |

### What changed
- **ContentCard.astro** — \contributor\ prop → \uthor\, type-aware label, removed contributor profile link
- **FlyoutPanel.astro** — shows author with label instead of contributor
- **Schemas** — added optional \uthor\ field to resources and tools
- **Issue templates** — added 'Creator / Author' input to resource.yml and tool.yml
- **Workflow** — captures and writes \uthor\ for resource and tool submissions
- **All pages** — homepage, articles, videos, resources, tools, events, tags, contributors updated
- **Article dates** — fixed triple date display (removed redundant Published/Submitted slots)
- **CONVENTIONS.md** — added rule: never merge/close PRs without explicit request

### Notes
- \contributor\ field remains in schemas for internal tracking and /contributors/ pages
- Author is optional for resources/tools (backward compatible with existing content)

Closes #43, Closes #44