### PR TITLE
fix: render markdown in content card descriptions

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -9,10 +9,11 @@ Every change, no matter how small, follows this process:
 1. **Branch** - Create a feature branch from `main` (`add/feature-name` or `fix/bug-name`)
 2. **Implement** - Make changes incrementally, one logical change at a time
 3. **Verify** - Run `npm run build` locally before committing. Build must pass with zero errors.
-4. **Commit** - Use conventional commit messages (see below). One concern per commit.
-5. **Push & PR** - Open a Pull Request against `main`. CI workflow runs automatically.
-6. **Review** - CI must pass. Maintainer reviews before merge.
-7. **Deploy** - Merging to `main` triggers automatic deployment to GitHub Pages.
+4. **Local Review** - Start the dev server (`npm run dev`) and let the maintainer review changes in the browser before creating a PR.
+5. **Commit** - Use conventional commit messages (see below). One concern per commit.
+6. **Push & PR** - Open a Pull Request against `main` only after the maintainer has reviewed locally. CI workflow runs automatically.
+7. **Review** - CI must pass. Maintainer reviews before merge.
+8. **Deploy** - Merging to `main` triggers automatic deployment to GitHub Pages.
 
 **Important:** Never merge or close PRs automatically. Only the maintainer merges or closes PRs unless explicitly asked to do so.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@astrojs/sitemap": "^3.7.1",
         "@astrojs/tailwind": "^6.0.2",
         "astro": "^5.18.0",
+        "marked": "^17.0.4",
         "pagefind": "^1.4.0",
         "tailwindcss": "^3.4.19"
       },
@@ -3888,6 +3889,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
+      "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@astrojs/sitemap": "^3.7.1",
     "@astrojs/tailwind": "^6.0.2",
     "astro": "^5.18.0",
+    "marked": "^17.0.4",
     "pagefind": "^1.4.0",
     "tailwindcss": "^3.4.19"
   },

--- a/src/components/ContentCard.astro
+++ b/src/components/ContentCard.astro
@@ -1,4 +1,6 @@
 ---
+import { marked } from 'marked';
+
 interface Props {
   title: string;
   description?: string;
@@ -107,7 +109,7 @@ const domain = url ? (() => {
 
   <!-- Description -->
   {description && (
-    <p class="mb-4 text-sm leading-relaxed text-gray-500 line-clamp-3 dark:text-muted">{description}</p>
+    <p class="mb-4 text-sm leading-relaxed text-gray-500 line-clamp-3 dark:text-muted" set:html={marked.parseInline(description)} />
   )}
 
   <!-- Tags -->

--- a/src/components/FlyoutPanel.astro
+++ b/src/components/FlyoutPanel.astro
@@ -81,6 +81,8 @@
 </aside>
 
 <script>
+import { marked } from 'marked';
+
 function initFlyout() {
   const backdrop = document.getElementById('flyout-backdrop');
   const panel = document.getElementById('flyout-panel');
@@ -95,7 +97,7 @@ function initFlyout() {
 
     document.getElementById('flyout-type-badge')!.textContent = `${typeIcons[data.type] || '📄'} ${data.type}`;
     document.getElementById('flyout-title')!.textContent = data.title;
-    document.getElementById('flyout-description')!.textContent = data.description || '';
+    document.getElementById('flyout-description')!.innerHTML = marked.parseInline(data.description || '') as string;
 
     // Source domain
     const domainEl = document.getElementById('flyout-domain')!;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import ContentCard from '../components/ContentCard.astro';
 import JsonLd from '../components/JsonLd.astro';
 import { getCollection } from 'astro:content';
+import { marked } from 'marked';
 
 // Fetch all collections
 const allArticles = await getCollection('articles');
@@ -476,7 +477,7 @@ const sections = [
                 <span class={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize ${c.bg} ${c.text}`}>{path.data.difficulty}</span>
               </div>
               <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-light group-hover:text-teal transition-colors">{path.data.title}</h3>
-              <p class="mb-4 text-sm leading-relaxed text-gray-500 dark:text-muted line-clamp-3">{path.data.description}</p>
+              <p class="mb-4 text-sm leading-relaxed text-gray-500 dark:text-muted line-clamp-3" set:html={marked.parseInline(path.data.description)} />
               <div class="flex items-center gap-4 text-xs text-gray-400 dark:text-muted/60">
                 <span class="inline-flex items-center gap-1">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg>
@@ -572,7 +573,7 @@ const sections = [
                 <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
               </svg>
             </h3>
-            <p class="mb-4 text-sm leading-relaxed text-gray-500 dark:text-muted line-clamp-3">{post.data.description}</p>
+            <p class="mb-4 text-sm leading-relaxed text-gray-500 dark:text-muted line-clamp-3" set:html={marked.parseInline(post.data.description)} />
             {post.data.tags.length > 0 && (
               <div class="mb-3 flex flex-wrap gap-1.5">
                 {post.data.tags.map((tag: string) => (


### PR DESCRIPTION
## Summary

Renders inline markdown (bold, italic, links, code) in content card descriptions using \marked.parseInline()\.

### Changes
- **ContentCard.astro** — server-side markdown rendering via \set:html\
- **FlyoutPanel.astro** — client-side rendering via \marked\ import + \.innerHTML\
- **index.astro** — LinkedIn posts and learning paths descriptions
- **package.json** — added \marked\ dependency
- **CONVENTIONS.md** — added local review step

Fixes #42