### PR TITLE
cleanup: remove dummy LinkedIn entries, fix video speaker

### DIFF
--- a/src/content/linkedin/building-agents-with-fabric.md
+++ b/src/content/linkedin/building-agents-with-fabric.md
@@ -1,9 +1,0 @@
----
-title: "My Experience Building Data Agents with Fabric"
-linkedinUrl: "https://www.linkedin.com/posts/activity-7200000000000000001"
-author: "Community Contributor"
-description: "A practitioner's journey building their first data agent in Microsoft Fabric. Covers lessons learned, tips for getting started, and common pitfalls to avoid."
-tags: ["experience", "tutorial", "getting-started"]
-contributor: "Sandeep Pawar"
-submittedDate: 2026-02-01
----

--- a/src/content/linkedin/fabric-data-agent-announcement.md
+++ b/src/content/linkedin/fabric-data-agent-announcement.md
@@ -1,9 +1,0 @@
----
-title: "Microsoft Fabric Data Agent - Game Changer for Analytics"
-linkedinUrl: "https://www.linkedin.com/posts/activity-7200000000000000000"
-author: "Microsoft Fabric Team"
-description: "An exciting announcement about the new Data Agent capabilities in Microsoft Fabric. The post covers how data agents can transform the way teams interact with data using natural language."
-tags: ["announcement", "fabric", "data-agent"]
-contributor: "Sandeep Pawar"
-submittedDate: 2026-01-15
----

--- a/src/content/videos/fabric-data-agents-and-beyond.md
+++ b/src/content/videos/fabric-data-agents-and-beyond.md
@@ -1,7 +1,7 @@
 ---
 title: "Fabric Data Agents and Beyond"
 youtubeId: "Jc2fYdxRdEo"
-speaker: "Microsoft Fabric Community"
+speaker: "Mathias Halkjær"
 publishDate: 2025-06-01
 description: "Explores the broader vision for Fabric Data Agents, including advanced use cases, multi-source data access, integration with Azure AI Agent Service, and how agents go beyond simple Q&A to enable enterprise-scale AI workflows."
 tags: ["advanced", "architecture", "azure-ai", "enterprise", "integration"]


### PR DESCRIPTION
Removed 2 dummy LinkedIn posts with fake URLs and fixed speaker name on Fabric Data Agents and Beyond video to Mathias Halkjaer.