### PR TITLE
feat: add sort-by dropdown to content listing pages

### DIFF
--- a/src/components/SortDropdown.astro
+++ b/src/components/SortDropdown.astro
@@ -1,0 +1,34 @@
+---
+interface Props {
+  options: { value: string; label: string }[];
+  defaultValue?: string;
+}
+
+const { options, defaultValue } = Astro.props;
+---
+
+<div class="sort-dropdown relative inline-flex items-center gap-2">
+  <label class="text-xs font-medium text-gray-400 dark:text-muted/60 whitespace-nowrap">Sort by</label>
+  <select
+    class="sort-select appearance-none rounded-lg border border-gray-200 bg-white px-3 py-1.5 pr-8 text-sm font-medium text-gray-700 transition-all duration-300 hover:border-teal/30 focus:border-teal focus:outline-none focus:ring-1 focus:ring-teal/30 dark:border-indigo/20 dark:bg-dark/60 dark:text-muted dark:hover:border-teal/30"
+  >
+    {options.map((opt) => (
+      <option value={opt.value} selected={opt.value === defaultValue}>
+        {opt.label}
+      </option>
+    ))}
+  </select>
+  <svg class="pointer-events-none absolute right-2 h-4 w-4 text-gray-400 dark:text-muted/60" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
+  </svg>
+</div>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll<HTMLSelectElement>('.sort-select').forEach((select) => {
+      select.addEventListener('change', () => {
+        select.dispatchEvent(new CustomEvent('sort-change', { bubbles: true, detail: { value: select.value } }));
+      });
+    });
+  });
+</script>

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import PageHeader from '../../components/PageHeader.astro';
 import ContentCard from '../../components/ContentCard.astro';
 import TagFilter from '../../components/TagFilter.astro';
+import SortDropdown from '../../components/SortDropdown.astro';
 import JsonLd from '../../components/JsonLd.astro';
 import { getCollection } from 'astro:content';
 
@@ -28,20 +29,35 @@ const allTags = [...new Set(articles.flatMap((a) => a.data.tags))].sort();
   />
 
   <section class="mx-auto max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
-    <TagFilter tags={allTags} />
+    <div class="flex flex-wrap items-start justify-between gap-4 mb-2">
+      <div class="flex-1 min-w-0"><TagFilter tags={allTags} /></div>
+      <SortDropdown
+        options={[
+          { value: 'published', label: 'Published Date' },
+          { value: 'submitted', label: 'Submitted Date' },
+        ]}
+        defaultValue="published"
+      />
+    </div>
 
     {articles.length > 0 ? (
-      <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div id="articles-grid" class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {articles.map((article) => (
-          <ContentCard
-            title={article.data.title}
-            description={article.data.summary}
-            url={article.data.url}
-            tags={article.data.tags}
-            author={article.data.author}
-            type="article"
-            date={new Date(article.data.publishDate).toLocaleDateString()}
-          />
+          <div
+            data-sort-publish={new Date(article.data.publishDate).getTime()}
+            data-sort-submitted={article.data.submittedDate ? new Date(article.data.submittedDate).getTime() : new Date(article.data.publishDate).getTime()}
+            data-tags={article.data.tags.join(',')}
+          >
+            <ContentCard
+              title={article.data.title}
+              description={article.data.summary}
+              url={article.data.url}
+              tags={article.data.tags}
+              author={article.data.author}
+              type="article"
+              date={new Date(article.data.publishDate).toLocaleDateString()}
+            />
+          </div>
         ))}
       </div>
     ) : (
@@ -53,4 +69,19 @@ const allTags = [...new Set(articles.flatMap((a) => a.data.tags))].sort();
       </div>
     )}
   </section>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const grid = document.getElementById('articles-grid');
+      if (!grid) return;
+
+      document.addEventListener('sort-change', ((e: CustomEvent) => {
+        const sortKey = e.detail.value;
+        const attr = sortKey === 'submitted' ? 'data-sort-submitted' : 'data-sort-publish';
+        const items = [...grid.children] as HTMLElement[];
+        items.sort((a, b) => Number(b.getAttribute(attr)) - Number(a.getAttribute(attr)));
+        items.forEach((item) => grid.appendChild(item));
+      }) as EventListener);
+    });
+  </script>
 </BaseLayout>

--- a/src/pages/events/index.astro
+++ b/src/pages/events/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import PageHeader from '../../components/PageHeader.astro';
 import ContentCard from '../../components/ContentCard.astro';
 import TagFilter from '../../components/TagFilter.astro';
+import SortDropdown from '../../components/SortDropdown.astro';
 import JsonLd from '../../components/JsonLd.astro';
 import { getCollection } from 'astro:content';
 
@@ -53,14 +54,23 @@ function formatEventDate(date: Date, endDate?: Date): string {
   />
 
   <section class="mx-auto max-w-7xl px-4 pb-16 sm:px-6 lg:px-8">
-    <TagFilter tags={allTags} />
+    <div class="flex flex-wrap items-start justify-between gap-4 mb-2">
+      <div class="flex-1 min-w-0"><TagFilter tags={allTags} /></div>
+      <SortDropdown
+        options={[
+          { value: 'date', label: 'Event Date' },
+          { value: 'title', label: 'Title A–Z' },
+        ]}
+        defaultValue="date"
+      />
+    </div>
 
     <!-- Upcoming Events -->
     <h2 class="mb-6 mt-8 text-2xl font-bold text-gray-900 dark:text-light">📅 Upcoming Events</h2>
     {upcoming.length > 0 ? (
-      <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div id="upcoming-grid" class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {upcoming.map((event) => (
-          <div class="flex flex-col" data-tags={event.data.tags.join(',')}>
+          <div class="flex flex-col" data-tags={event.data.tags.join(',')} data-sort-date={new Date(event.data.date).getTime()} data-sort-title={event.data.title.toLowerCase()}>
             <ContentCard
               title={event.data.title}
               description={event.data.description}
@@ -97,10 +107,9 @@ function formatEventDate(date: Date, endDate?: Date): string {
     <!-- Past Events -->
     <h2 class="mb-6 mt-16 text-2xl font-bold text-gray-900 dark:text-light">🕒 Past Events</h2>
     {past.length > 0 ? (
-      <div class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <div id="past-grid" class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {past.map((event) => (
-          <div class="flex flex-col opacity-75" data-tags={event.data.tags.join(',')}>
-            <ContentCard
+          <div class="flex flex-col opacity-75" data-tags={event.data.tags.join(',')} data-sort-date={new Date(event.data.date).getTime()} data-sort-title={event.data.title.toLowerCase()}>            <ContentCard
               title={event.data.title}
               description={event.data.description}
               url={event.data.url}
@@ -131,4 +140,30 @@ function formatEventDate(date: Date, endDate?: Date): string {
       </div>
     )}
   </section>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const upcomingGrid = document.getElementById('upcoming-grid');
+      const pastGrid = document.getElementById('past-grid');
+
+      document.addEventListener('sort-change', ((e: CustomEvent) => {
+        const sortKey = e.detail.value;
+
+        [upcomingGrid, pastGrid].forEach((grid, idx) => {
+          if (!grid) return;
+          const items = [...grid.children] as HTMLElement[];
+          if (sortKey === 'title') {
+            items.sort((a, b) => (a.getAttribute('data-sort-title') || '').localeCompare(b.getAttribute('data-sort-title') || ''));
+          } else {
+            // Upcoming: ascending (soonest first), Past: descending (most recent first)
+            items.sort((a, b) => {
+              const diff = Number(a.getAttribute('data-sort-date')) - Number(b.getAttribute('data-sort-date'));
+              return idx === 0 ? diff : -diff;
+            });
+          }
+          items.forEach((item) => grid.appendChild(item));
+        });
+      }) as EventListener);
+    });
+  </script>
 </BaseLayout>

--- a/src/pages/linkedin/index.astro
+++ b/src/pages/linkedin/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import TagFilter from '../../components/TagFilter.astro';
+import SortDropdown from '../../components/SortDropdown.astro';
 import PageHeader from '../../components/PageHeader.astro';
 import JsonLd from '../../components/JsonLd.astro';
 
@@ -33,7 +34,16 @@ function extractLinkedInActivityId(url: string): string | null {
   />
 
   <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
-    {allTags.length > 0 && <TagFilter tags={allTags} />}
+    <div class="flex flex-wrap items-start justify-between gap-4 mb-2">
+      <div class="flex-1 min-w-0">{allTags.length > 0 && <TagFilter tags={allTags} />}</div>
+      <SortDropdown
+        options={[
+          { value: 'submitted', label: 'Date Submitted' },
+          { value: 'title', label: 'Title A–Z' },
+        ]}
+        defaultValue="submitted"
+      />
+    </div>
 
     {posts.length === 0 ? (
       <div class="text-center py-20">
@@ -41,7 +51,7 @@ function extractLinkedInActivityId(url: string): string | null {
         <p class="mt-2 text-sm text-gray-400 dark:text-muted/60">Have a post to share? <a href={`${base}contribute/`} class="text-teal underline decoration-teal/30 underline-offset-2 hover:text-tealDark">Contribute</a></p>
       </div>
     ) : (
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
+      <div id="linkedin-grid" class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
         {posts.map((post) => {
           const activityId = extractLinkedInActivityId(post.data.linkedinUrl);
           const formattedDate = new Date(post.data.submittedDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
@@ -49,6 +59,8 @@ function extractLinkedInActivityId(url: string): string | null {
             <div
               class="group rounded-2xl border border-gray-200 bg-white/60 dark:border-indigo/20 dark:bg-dark/50 backdrop-blur-sm overflow-hidden transition-all duration-300 hover:border-teal/40 hover:shadow-[0_0_20px_rgba(0,212,170,0.15)] hover:scale-[1.01]"
               data-tags={post.data.tags.join(',')}
+              data-sort-submitted={new Date(post.data.submittedDate).getTime()}
+              data-sort-title={post.data.title.toLowerCase()}
             >
               {/* LinkedIn Embed */}
               {activityId ? (
@@ -132,4 +144,22 @@ function extractLinkedInActivityId(url: string): string | null {
       </div>
     )}
   </section>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const grid = document.getElementById('linkedin-grid');
+      if (!grid) return;
+
+      document.addEventListener('sort-change', ((e: CustomEvent) => {
+        const sortKey = e.detail.value;
+        const items = [...grid.children] as HTMLElement[];
+        if (sortKey === 'title') {
+          items.sort((a, b) => (a.getAttribute('data-sort-title') || '').localeCompare(b.getAttribute('data-sort-title') || ''));
+        } else {
+          items.sort((a, b) => Number(b.getAttribute('data-sort-submitted')) - Number(a.getAttribute('data-sort-submitted')));
+        }
+        items.forEach((item) => grid.appendChild(item));
+      }) as EventListener);
+    });
+  </script>
 </BaseLayout>

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import TagFilter from '../../components/TagFilter.astro';
+import SortDropdown from '../../components/SortDropdown.astro';
 import PageHeader from '../../components/PageHeader.astro';
 import JsonLd from '../../components/JsonLd.astro';
 
@@ -28,7 +29,16 @@ const allTags = [...new Set(videos.flatMap((v) => v.data.tags))].sort();
   />
 
   <section class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
-    {allTags.length > 0 && <TagFilter tags={allTags} />}
+    <div class="flex flex-wrap items-start justify-between gap-4 mb-2">
+      <div class="flex-1 min-w-0">{allTags.length > 0 && <TagFilter tags={allTags} />}</div>
+      <SortDropdown
+        options={[
+          { value: 'published', label: 'Published Date' },
+          { value: 'title', label: 'Title A–Z' },
+        ]}
+        defaultValue="published"
+      />
+    </div>
 
     {videos.length === 0 ? (
       <div class="text-center py-20">
@@ -36,11 +46,13 @@ const allTags = [...new Set(videos.flatMap((v) => v.data.tags))].sort();
         <p class="mt-2 text-sm text-gray-400 dark:text-muted/60">Have a video to share? <a href={`${base}contribute/`} class="text-teal underline decoration-teal/30 underline-offset-2 hover:text-tealDark">Contribute</a></p>
       </div>
     ) : (
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
+      <div id="videos-grid" class="grid grid-cols-1 lg:grid-cols-2 gap-8 mt-8">
         {videos.map((video) => (
           <div
             class="group rounded-2xl border border-gray-200 bg-white/60 dark:border-indigo/20 dark:bg-dark/50 backdrop-blur-sm overflow-hidden transition-all duration-300 hover:border-teal/40 hover:shadow-[0_0_20px_rgba(0,212,170,0.15)] hover:scale-[1.01]"
             data-tags={video.data.tags.join(',')}
+            data-sort-publish={new Date(video.data.publishDate).getTime()}
+            data-sort-title={video.data.title.toLowerCase()}
           >
             <div class="aspect-video w-full">
               <iframe
@@ -92,4 +104,22 @@ const allTags = [...new Set(videos.flatMap((v) => v.data.tags))].sort();
       </div>
     )}
   </section>
+
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const grid = document.getElementById('videos-grid');
+      if (!grid) return;
+
+      document.addEventListener('sort-change', ((e: CustomEvent) => {
+        const sortKey = e.detail.value;
+        const items = [...grid.children] as HTMLElement[];
+        if (sortKey === 'title') {
+          items.sort((a, b) => (a.getAttribute('data-sort-title') || '').localeCompare(b.getAttribute('data-sort-title') || ''));
+        } else {
+          items.sort((a, b) => Number(b.getAttribute('data-sort-publish')) - Number(a.getAttribute('data-sort-publish')));
+        }
+        items.forEach((item) => grid.appendChild(item));
+      }) as EventListener);
+    });
+  </script>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Adds a reusable SortDropdown component and integrates it on Articles, Videos, Events, and LinkedIn pages. All sorting is client-side via DOM reordering — no rebuild needed.

### Sort options per page

| Page | Default Sort | Additional Option |
|------|-------------|-------------------|
| Articles | Published Date | Submitted Date |
| Videos | Published Date | Title A–Z |
| Events | Event Date | Title A–Z |
| LinkedIn | Date Submitted | Title A–Z |

### Changes
- **New component**: \src/components/SortDropdown.astro\ — styled dropdown matching dark/light theme
- **Articles page**: sort by Published Date (default) or Submitted Date
- **Videos page**: sort by Published Date (default) or Title A–Z
- **Events page**: sort by Event Date (default) or Title A–Z (applies to both Upcoming and Past sections)
- **LinkedIn page**: sort by Date Submitted (default) or Title A–Z

### Build
✅ 77 pages built successfully