### PR TITLE
fix: use site logo as favicon

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,8 +45,7 @@ const ogImageUrl = ogImage || `${base}data-agent-logo.png`;
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cloud.umami.is https://d3js.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com https://www.linkedin.com; connect-src 'self' https://cloud.umami.is;" />
-    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
-    <link rel="icon" href={`${base}favicon.ico`} />
+    <link rel="icon" type="image/png" href={`${base}data-agent-logo.png`} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />


### PR DESCRIPTION
Replaces the default Astro rocket favicon with the data-agent-logo.png so the browser tab shows the correct site icon.