### PR TITLE
fix: accept YouTube URL in video template and merge PR directly

### DIFF
--- a/.github/ISSUE_TEMPLATE/video.yml
+++ b/.github/ISSUE_TEMPLATE/video.yml
@@ -10,9 +10,9 @@ body:
   - type: input
     id: youtube_id
     attributes:
-      label: YouTube Video ID
-      description: The ID from the YouTube URL. For example, if the URL is https://youtube.com/watch?v=abc123, the ID is "abc123".
-      placeholder: "abc123"
+      label: YouTube Video URL or ID
+      description: Paste the full YouTube URL (e.g. https://www.youtube.com/watch?v=abc123) or just the video ID.
+      placeholder: "https://www.youtube.com/watch?v=abc123"
     validations:
       required: true
 

--- a/.github/workflows/add-content.yml
+++ b/.github/workflows/add-content.yml
@@ -226,7 +226,7 @@ jobs:
               }
 
             } else if (contentType === 'video') {
-              const youtubeId = extractYouTubeId(parseField(body, 'YouTube Video ID'));
+              const youtubeId = extractYouTubeId(parseField(body, 'YouTube Video URL or ID'));
               const speaker = parseField(body, 'Speaker / Presenter');
               const publishDate = validateDate(parseField(body, 'Publish Date'));
               const description = parseField(body, 'Description');
@@ -470,7 +470,7 @@ jobs:
             -f context=check \
             -f description="Build validated in content workflow"
 
-          gh pr merge "$BRANCH" --auto --merge --delete-branch
+          gh pr merge "$BRANCH" --merge --delete-branch
 
       - name: Comment and close issue
         if: success()
@@ -485,7 +485,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `Your ${contentType} submission has been approved! A PR has been created and will be auto-merged once CI passes.\n\nThe content file \`${filePath}\` will be live on the site within a few minutes. Thank you for contributing!`
+              body: `Your ${contentType} submission has been approved! A PR has been created and merged.\n\nThe content file \`${filePath}\` will be live on the site within a few minutes. Thank you for contributing!`
             });
 
             await github.rest.issues.update({


### PR DESCRIPTION
## Changes

1. **Video issue template**: Users can now paste a full YouTube URL (e.g. \https://www.youtube.com/watch?v=abc123\) instead of having to extract the video ID manually.

2. **Auto-merge fix**: Changed \gh pr merge --auto\ to \gh pr merge\ (direct merge). The auto-merge was failing with \Pull request is in clean status\ error because there are no required status checks blocking the PR.

3. **Updated issue comment** to reflect direct merge instead of auto-merge.