### PR TITLE
improve: clarify format requirements in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/article.yml
+++ b/.github/ISSUE_TEMPLATE/article.yml
@@ -11,8 +11,8 @@ body:
     id: url
     attributes:
       label: Article URL
-      description: The full URL to the article.
-      placeholder: "https://example.com/my-article"
+      description: Must start with https://
+      placeholder: "https://blog.fabric.microsoft.com/en-us/blog/my-article"
     validations:
       required: true
 
@@ -29,7 +29,7 @@ body:
     id: publish_date
     attributes:
       label: Publish Date
-      description: When the article was published (YYYY-MM-DD).
+      description: Format YYYY-MM-DD
       placeholder: "2025-06-15"
     validations:
       required: true
@@ -38,7 +38,7 @@ body:
     id: summary
     attributes:
       label: Summary
-      description: A brief description of what the article covers (2-3 sentences).
+      description: 2-3 sentences about the article. Required.
       placeholder: "This article explains how to..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/event.yml
+++ b/.github/ISSUE_TEMPLATE/event.yml
@@ -11,8 +11,8 @@ body:
     id: url
     attributes:
       label: Event URL
-      description: Link to the event page or registration.
-      placeholder: "https://example.com/event"
+      description: Must start with https://
+      placeholder: "https://developer.microsoft.com/en-us/reactor/events/my-event"
     validations:
       required: true
 
@@ -20,7 +20,7 @@ body:
     id: date
     attributes:
       label: Event Date
-      description: When the event takes place (YYYY-MM-DD).
+      description: Format YYYY-MM-DD
       placeholder: "2026-06-15"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/linkedin.yml
+++ b/.github/ISSUE_TEMPLATE/linkedin.yml
@@ -11,7 +11,7 @@ body:
     id: linkedin_url
     attributes:
       label: LinkedIn Post URL
-      description: The full URL to the LinkedIn post.
+      description: Must start with https://www.linkedin.com/
       placeholder: "https://www.linkedin.com/posts/..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/resource.yml
+++ b/.github/ISSUE_TEMPLATE/resource.yml
@@ -11,7 +11,7 @@ body:
     id: url
     attributes:
       label: Resource URL
-      description: The full URL to the resource.
+      description: Must start with https://
       placeholder: "https://learn.microsoft.com/..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/tool.yml
+++ b/.github/ISSUE_TEMPLATE/tool.yml
@@ -11,7 +11,7 @@ body:
     id: url
     attributes:
       label: Tool URL
-      description: Link to the tool's homepage, repository, or documentation.
+      description: Must start with https://
       placeholder: "https://github.com/example/tool"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/video.yml
+++ b/.github/ISSUE_TEMPLATE/video.yml
@@ -29,7 +29,7 @@ body:
     id: publish_date
     attributes:
       label: Publish Date
-      description: When the video was published (YYYY-MM-DD).
+      description: Format YYYY-MM-DD
       placeholder: "2025-06-15"
     validations:
       required: true


### PR DESCRIPTION
Makes URL and date format requirements visible while filling out the form. Short descriptions like 'Must start with https://' and 'Format YYYY-MM-DD' so users know the expected format upfront.