### PR TITLE
fix: LinkedIn embed for activity: URL format

### DIFF
--- a/src/pages/linkedin/index.astro
+++ b/src/pages/linkedin/index.astro
@@ -16,7 +16,7 @@ const posts = allPosts.sort(
 const allTags = [...new Set(posts.flatMap((p) => p.data.tags))].sort();
 
 function extractLinkedInActivityId(url: string): string | null {
-  const match = url.match(/activity-(\d+)/);
+  const match = url.match(/activity[:\-](\d+)/);
   return match ? match[1] : null;
 }
 ---


### PR DESCRIPTION
The regex for extracting LinkedIn activity IDs only matched \ctivity-\ (hyphen) but LinkedIn URLs also use \ctivity:\ (colon). Now supports both formats so embeds render correctly.