### PR TITLE
remove: Fabric Data Agent Testing Framework and notebook utilities

### DIFF
--- a/src/content/tools/fabric-data-agent-testing-framework.md
+++ b/src/content/tools/fabric-data-agent-testing-framework.md
@@ -1,8 +1,0 @@
----
-title: "Fabric Data Agent Testing Framework"
-url: "https://github.com/microsoft/fabric-agent-testing"
-description: "A testing framework for validating data agent responses, benchmarking query accuracy, and running automated regression tests against Fabric data agents."
-category: "Testing"
-tags: ["testing", "qa", "automation"]
-contributor: "Sandeep Pawar"
----

--- a/src/content/tools/fabric-notebook-utilities.md
+++ b/src/content/tools/fabric-notebook-utilities.md
@@ -1,8 +1,0 @@
----
-title: "Fabric Notebook Utilities"
-url: "https://github.com/microsoft/fabric-notebook-utils"
-description: "A Python library providing utility functions for working with Fabric notebooks, including data agent helpers, semantic model connectors, and testing utilities."
-category: "Library"
-tags: ["python", "notebooks", "utilities"]
-contributor: "Sandeep Pawar"
----


### PR DESCRIPTION
Removes two tools from the site as requested.