### PR TITLE
feat: mark intermediate and advanced learning paths as Coming Soon

### DIFF
--- a/src/pages/learn/index.astro
+++ b/src/pages/learn/index.astro
@@ -35,17 +35,24 @@ const difficultyStyles: Record<string, { bg: string; text: string; label: string
       <div class="grid grid-cols-1 gap-8 lg:grid-cols-2">
         {paths.map((path) => {
           const style = difficultyStyles[path.data.difficulty];
+          const comingSoon = path.data.difficulty === 'intermediate' || path.data.difficulty === 'advanced';
+          const Wrapper = comingSoon ? 'div' : 'a';
           return (
-            <a
-              href={`${base}learn/${path.id}/`}
-              class="group relative flex flex-col rounded-xl border border-gray-200 bg-white/60 dark:border-indigo/20 dark:bg-dark/60 p-6 backdrop-blur-sm transition-all duration-300 hover:border-teal/30 hover:shadow-[0_0_30px_rgba(0,212,170,0.15)] hover:scale-[1.02]"
+            <Wrapper
+              {...(!comingSoon && { href: `${base}learn/${path.id}/` })}
+              class={`group relative flex flex-col rounded-xl border border-gray-200 bg-white/60 dark:border-indigo/20 dark:bg-dark/60 p-6 backdrop-blur-sm transition-all duration-300 ${comingSoon ? 'opacity-60 cursor-default' : 'hover:border-teal/30 hover:shadow-[0_0_30px_rgba(0,212,170,0.15)] hover:scale-[1.02]'}`}
             >
               {/* Difficulty badge */}
               <div class="mb-4 flex items-center gap-3">
                 <span class={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${style.bg} ${style.text}`}>
                   {style.label}
                 </span>
-                {path.data.estimatedTime && (
+                {comingSoon && (
+                  <span class="inline-flex items-center rounded-full bg-gray-200 dark:bg-indigo/20 px-3 py-1 text-xs font-semibold text-gray-500 dark:text-muted">
+                    Coming Soon
+                  </span>
+                )}
+                {!comingSoon && path.data.estimatedTime && (
                   <span class="inline-flex items-center gap-1 text-xs text-gray-500 dark:text-muted">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -83,7 +90,7 @@ const difficultyStyles: Record<string, { bg: string; text: string; label: string
                   ))}
                 </div>
               )}
-            </a>
+            </Wrapper>
           );
         })}
       </div>


### PR DESCRIPTION
Intermediate and advanced learning paths now show a Coming Soon badge, are dimmed, and are not clickable. Beginner path remains fully active.