### PR TITLE
Add Coming Soon badge to homepage learning paths

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -471,10 +471,14 @@ const sections = [
       <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {learnPaths.map((path) => {
           const c = difficultyColors[path.data.difficulty] || difficultyColors.beginner;
+          const comingSoon = path.data.difficulty !== 'beginner';
+          const Wrapper = comingSoon ? 'div' : 'a';
+          const wrapperProps = comingSoon ? {} : { href: `${base}learn/${path.id}/` };
           return (
-            <a href={`${base}learn/${path.id}/`} class="group rounded-xl border border-gray-200 bg-white/60 dark:border-indigo/20 dark:bg-dark/60 p-5 backdrop-blur-sm transition-all duration-300 hover:border-teal/30 hover:shadow-[0_0_20px_rgba(0,212,170,0.15)] hover:scale-[1.02] block">
+            <Wrapper {...wrapperProps} class={`group rounded-xl border border-gray-200 bg-white/60 dark:border-indigo/20 dark:bg-dark/60 p-5 backdrop-blur-sm transition-all duration-300 block ${comingSoon ? 'opacity-60 cursor-default' : 'hover:border-teal/30 hover:shadow-[0_0_20px_rgba(0,212,170,0.15)] hover:scale-[1.02]'}`}>
               <div class="mb-3 flex items-center gap-2">
                 <span class={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold capitalize ${c.bg} ${c.text}`}>{path.data.difficulty}</span>
+                {comingSoon && <span class="inline-block rounded-full bg-gray-200 dark:bg-gray-700 px-2.5 py-0.5 text-xs font-semibold text-gray-500 dark:text-gray-400">Coming Soon</span>}
               </div>
               <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-light group-hover:text-teal transition-colors">{path.data.title}</h3>
               <p class="mb-4 text-sm leading-relaxed text-gray-500 dark:text-muted line-clamp-3" set:html={marked.parseInline(path.data.description)} />
@@ -490,7 +494,7 @@ const sections = [
                   </span>
                 )}
               </div>
-            </a>
+            </Wrapper>
           );
         })}
       </div>


### PR DESCRIPTION
Matches the learn page behavior: intermediate and advanced paths show a Coming Soon badge, are dimmed, and are not clickable.