### PR TITLE
fix(umami): set host-url so analytics events get through CSP

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -44,7 +44,7 @@ const ogImageUrl = ogImage || `${base}data-agent-logo.png`;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cloud.umami.is https://d3js.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com https://www.linkedin.com; connect-src 'self' https://cloud.umami.is;" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cloud.umami.is https://d3js.org; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; frame-src https://www.youtube.com https://www.linkedin.com; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev;" />
     <link rel="icon" type="image/png" href={`${base}data-agent-logo.png`} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -68,7 +68,7 @@ const ogImageUrl = ogImage || `${base}data-agent-logo.png`;
     <meta name="twitter:image" content={ogImageUrl} />
 
     <ClientRouter />
-    {umamiId && <script defer src={umamiSrc} data-website-id={umamiId}></script>}
+    {umamiId && <script defer src={umamiSrc} data-website-id={umamiId} data-host-url="https://cloud.umami.is"></script>}
   </head>
   <body class="min-h-screen bg-gray-50 font-sans text-gray-900 antialiased dark:bg-darker dark:text-light">
     <!-- Dot grid background pattern -->


### PR DESCRIPTION
## Problem

Umami script tag was loading on the live site, but no analytics were being recorded.

## Root cause

Umami Cloud's tracker script defaults event POSTs to `https://api-gateway.umami.dev/api/send`, but the page CSP only allowed `https://cloud.umami.is` in `connect-src`. The browser silently blocked every tracking request.

## Fix

- Add `data-host-url="https://cloud.umami.is"` to the script tag so events POST back to the host already in CSP.
- Add `https://api-gateway.umami.dev` to `connect-src` as a safety net in case Umami changes defaults again.

## How to test locally

```powershell
git fetch
git checkout fix/umami-csp-host-url
# .env -> PUBLIC_UMAMI_WEBSITE_ID=8273c954-1d21-4cc1-9e6b-52890c524edf
npm ci
npm run build
npm run preview
```

Open DevTools → Network, filter by `umami`. You should see successful POSTs to `cloud.umami.is/api/send` returning 200, with no CSP violations in the Console.

Note: GitHub Pages can only deploy one site (from `main`), so this branch can't be deployed to a separate live URL. Local preview build is the closest equivalent — it uses the exact same CSP and the same Umami website ID via your local `.env`.
